### PR TITLE
rgbds 최신 버전에 따른 lb 매크로 수정

### DIFF
--- a/macros/asm_macros.asm
+++ b/macros/asm_macros.asm
@@ -1,6 +1,6 @@
 
 lb: MACRO ; r, hi, lo
-	ld \1, (\2) << 8 + ((\3) & $ff)
+	ld \1, ((\2) & $ff) << 8 + ((\3) & $ff)
 ENDM
 
 homecall: MACRO


### PR DESCRIPTION
rgbds 최신 버전에서는 lb 명령어 warning 오류 뜹니다.
변경 사항으로 수정하면 warning은 사라집니다.